### PR TITLE
Add `default-run` to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/railwayapp/cliv3"
 repository = "https://github.com/railwayapp/cliv3"
 rust-version = "1.67.1"
+default-run = "railway"
 
 [[bin]]
 name = "railway"


### PR DESCRIPTION
This makes `cargo run` commands a bit shorter.