### PR TITLE
feat<variables>: add the ability to choose which environment to pull variables from

### DIFF
--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -12,7 +12,7 @@ use super::{
 /// Show variables for active environment
 #[derive(Parser)]
 pub struct Args {
-    /// Show variables for a environment
+    /// Show variables for a specific environment
     environment: Option<String>,
     /// Show variables for a plugin
     #[clap(short, long)]

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -66,8 +66,6 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         linked_project.environment.clone()
     };
 
-    dbg!(&environment);
-
     let (vars, name) = if args.plugin {
         if plugins.is_empty() {
             bail!("No plugins found");

--- a/src/commands/variables.rs
+++ b/src/commands/variables.rs
@@ -12,6 +12,8 @@ use super::{
 /// Show variables for active environment
 #[derive(Parser)]
 pub struct Args {
+    /// Show variables for a environment
+    environment: Option<String>,
     /// Show variables for a plugin
     #[clap(short, long)]
     plugin: bool,
@@ -46,6 +48,26 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         .map(|plugin| Plugin(&plugin.node))
         .collect();
 
+    let environment = if let Some(environment) = args.environment.clone() {
+        let envs = &body
+            .project
+            .environments
+            .edges
+            .iter()
+            .map(|env| env.node.clone())
+            .find(|env| env.name == environment);
+
+        if envs.is_none() {
+            bail!("Environment not found");
+        }
+
+        envs.clone().unwrap().id
+    } else {
+        linked_project.environment.clone()
+    };
+
+    dbg!(&environment);
+
     let (vars, name) = if args.plugin {
         if plugins.is_empty() {
             bail!("No plugins found");
@@ -53,7 +75,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         let plugin = prompt_plugin(plugins)?;
         (
             queries::variables::Variables {
-                environment_id: linked_project.environment.clone(),
+                environment_id: environment,
                 project_id: linked_project.project.clone(),
                 service_id: None,
                 plugin_id: Some(plugin.0.id.clone()),
@@ -70,7 +92,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
             .context("Service not found")?;
         (
             queries::variables::Variables {
-                environment_id: linked_project.environment.clone(),
+                environment_id: environment,
                 project_id: linked_project.project.clone(),
                 service_id: Some(service.clone()),
                 plugin_id: None,
@@ -84,7 +106,7 @@ pub async fn command(args: Args, json: bool) -> Result<()> {
         let plugin = prompt_plugin(plugins)?;
         (
             queries::variables::Variables {
-                environment_id: linked_project.environment.clone(),
+                environment_id: environment,
                 project_id: linked_project.project.clone(),
                 service_id: None,
                 plugin_id: Some(plugin.0.id.clone()),


### PR DESCRIPTION
What does it do:

- allows `rlwy variables <environment name>`, then pulls variables from that specific environment.

Images:
<img width="609" alt="image" src="https://user-images.githubusercontent.com/26424336/220295241-40ac00f3-c0f3-4d55-a076-2ddef21d1b34.png">
<img width="614" alt="image" src="https://user-images.githubusercontent.com/26424336/220295280-ef1160d8-1e5e-4dde-ac77-d36abde7da01.png">

*i removed the dbg!() i promise