### PR TITLE
Basic library implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/railwayapp/cliv3"
 rust-version = "1.67.1"
 default-run = "railway"
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "railway"
 path = "src/main.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,40 @@
+use clap::{Parser, Subcommand};
+use crate::commands::*;
+/// Interact with 🚅 Railway via CLI
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+#[clap(propagate_version = true)]
+pub(crate) struct Args {
+    #[clap(subcommand)]
+    command: Commands,
+
+    /// Output in JSON format
+    #[clap(global = true, long)]
+    json: bool,
+}
+
+// Generates the commands based on the modules in the commands directory
+// Specify the modules you want to include in the commands_enum! macro
+commands_enum!(
+    add,
+    completion,
+    delete,
+    docs,
+    environment,
+    init,
+    link,
+    list,
+    login,
+    logout,
+    logs,
+    open,
+    run,
+    service,
+    shell,
+    starship,
+    status,
+    unlink,
+    up,
+    variables,
+    whoami
+);

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -13,7 +13,7 @@ pub struct Args {
 pub async fn command(args: Args, _json: bool) -> Result<()> {
     generate(
         args.shell,
-        &mut crate::Args::command(),
+        &mut crate::cli::Args::command(),
         "railway",
         &mut io::stdout(),
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod commands;
 
 pub mod client;
-pub(crate) mod config;
+pub mod config;
 pub(crate) mod consts;
 pub(crate) mod entities;
 pub mod gql;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,14 @@
+pub mod commands;
+
+pub mod client;
+pub(crate) mod config;
+pub(crate) mod consts;
+pub(crate) mod entities;
+pub mod gql;
+// mod subscription;
+pub(crate) mod table;
+
+#[macro_use]
+pub(crate) mod macros;
+
+pub(crate) mod cli;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,14 +2,15 @@ macro_rules! commands_enum {
     ($($module:tt),*) => (
       paste::paste! {
         #[derive(Subcommand)]
-        enum Commands {
+        pub(crate) enum Commands {
             $(
               [<$module:camel>]($module::Args),
             )*
         }
 
         impl Commands {
-            async fn exec(cli: Args) -> Result<()> {
+            #[allow(dead_code)]
+            pub(crate) async fn exec(cli: Args) -> Result<()> {
               match cli.command {
                 $(
                   Commands::[<$module:camel>](args) => $module::command(args, cli.json).await?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,58 +1,20 @@
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::Parser;
 
-mod commands;
-use commands::*;
-
-mod client;
-mod config;
-mod consts;
-mod entities;
-mod gql;
+pub mod client;
+pub(crate) mod config;
+pub(crate) mod consts;
+pub(crate) mod entities;
+pub mod gql;
 // mod subscription;
-mod table;
+pub(crate) mod table;
+mod commands;
 
 #[macro_use]
 mod macros;
 
-/// Interact with 🚅 Railway via CLI
-#[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
-#[clap(propagate_version = true)]
-pub struct Args {
-    #[clap(subcommand)]
-    command: Commands,
-
-    /// Output in JSON format
-    #[clap(global = true, long)]
-    json: bool,
-}
-
-// Generates the commands based on the modules in the commands directory
-// Specify the modules you want to include in the commands_enum! macro
-commands_enum!(
-    add,
-    completion,
-    delete,
-    docs,
-    environment,
-    init,
-    link,
-    list,
-    login,
-    logout,
-    logs,
-    open,
-    run,
-    service,
-    shell,
-    starship,
-    status,
-    unlink,
-    up,
-    variables,
-    whoami
-);
+mod cli;
+use cli::*;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
This exports `commands`, `client`, and `gql` to be used as a library.