### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1671096816,
+        "narHash": "sha256-ezQCsNgmpUHdZANDCILm3RvtO1xH8uujk/+EqNvzIOg=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "d998160d6a076cfe8f9741e56aeec7e267e3e114",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677050843,
+        "narHash": "sha256-3fcFxn58eCtrXrVPeW/nAg6NR5wUERVEf8zOtjPDzuM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e0eed654c705c7cafe192a8eba1610217f70544",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": [
+          "rust-overlay",
+          "flake-utils"
+        ],
+        "naersk": "naersk",
+        "nixpkgs": [
+          "rust-overlay",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1677033035,
+        "narHash": "sha256-w6XsKaW46kZNEk2vVfuoNIBEq/YzDy9kNk8cU0xJZEQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6c9e8ea3ba73a9fed29ddc1cc52ade8e5c946a8d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A flake for building a Rust workspace using buildRustPackage.";
+  description = "The new, improved, and rustified CLI for interacting with Railway";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/22.11";
@@ -22,6 +22,7 @@
           rustc = toolchain;
         };
         code = naersk'.buildPackage {
+          name = "railway";
           src = ./.;
         };
       in rec {
@@ -31,10 +32,8 @@
         };
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            openssl
-            pkg-config
-            cmake
-            rust-bin.beta.latest.default
+            gcc
+            rust-bin.stable.latest.default
           ];
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,102 +1,38 @@
-  {
-    "nodes": {
-      "flake-utils": {
-        "locked": {
-          "lastModified": 1659877975,
-          "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-          "owner": "numtide",
-          "repo": "flake-utils",
-          "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-          "type": "github"
-        },
-        "original": {
-          "owner": "numtide",
-          "repo": "flake-utils",
-          "type": "github"
-        }
-      },
-      "naersk": {
-        "inputs": {
-          "nixpkgs": "nixpkgs"
-        },
-        "locked": {
-          "lastModified": 1671096816,
-          "narHash": "sha256-ezQCsNgmpUHdZANDCILm3RvtO1xH8uujk/+EqNvzIOg=",
-          "owner": "nix-community",
-          "repo": "naersk",
-          "rev": "d998160d6a076cfe8f9741e56aeec7e267e3e114",
-          "type": "github"
-        },
-        "original": {
-          "owner": "nix-community",
-          "repo": "naersk",
-          "type": "github"
-        }
-      },
-      "nixpkgs": {
-        "locked": {
-          "lastModified": 1677413016,
-          "narHash": "sha256-dwvL0VK5iyxXPQzJOPzYmuVinh/R9hwRu7eYq6Bf6ag=",
-          "owner": "NixOS",
-          "repo": "nixpkgs",
-          "rev": "84e33aea0f7a8375c92458c5b6cad75fa1dd561b",
-          "type": "github"
-        },
-        "original": {
-          "id": "nixpkgs",
-          "type": "indirect"
-        }
-      },
-      "nixpkgs_2": {
-        "locked": {
-          "lastModified": 1665296151,
-          "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
-          "owner": "NixOS",
-          "repo": "nixpkgs",
-          "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
-          "type": "github"
-        },
-        "original": {
-          "owner": "NixOS",
-          "ref": "nixpkgs-unstable",
-          "repo": "nixpkgs",
-          "type": "github"
-        }
-      },
-      "root": {
-        "inputs": {
-          "flake-utils": [
-            "rust-overlay",
-            "flake-utils"
-          ],
-          "naersk": "naersk",
-          "nixpkgs": [
-            "rust-overlay",
-            "nixpkgs"
-          ],
-          "rust-overlay": "rust-overlay"
-        }
-      },
-      "rust-overlay": {
-        "inputs": {
-          "flake-utils": "flake-utils",
-          "nixpkgs": "nixpkgs_2"
-        },
-        "locked": {
-          "lastModified": 1677205778,
-          "narHash": "sha256-DFe09uzS+8LjGBAAyHkB/5Axs0j/PQ8RLWFzm2FUZLA=",
-          "owner": "oxalica",
-          "repo": "rust-overlay",
-          "rev": "b91706f9d5a68fecf97b63753da8e9670dff782b",
-          "type": "github"
-        },
-        "original": {
-          "owner": "oxalica",
-          "repo": "rust-overlay",
-          "type": "github"
-        }
+{
+  description = "Interact with Railway via CLI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/22.11";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.follows = "rust-overlay/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.follows = "rust-overlay/nixpkgs";
+  };
+
+  outputs = inputs: with inputs;
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        toolchain = pkgs.rust-bin.stable.latest.default;
+        naersk' = pkgs.callPackage naersk {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+        code = naersk'.buildPackage {
+          name = "railway";
+          src = ./.;
+        };
+      in
+      rec {
+        packages = {
+          cli = code;
+          default = packages.cli;
+        };
+        devShells.default =
+          import ./shell.nix { inherit pkgs; };
       }
-    },
-    "root": "root",
-    "version": 7
-  }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "A flake for building a Rust workspace using buildRustPackage.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/22.11";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.follows = "rust-overlay/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.follows = "rust-overlay/nixpkgs";
+  };
+
+  outputs = inputs: with inputs;
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        toolchain = pkgs.rust-bin.stable.latest.default;
+        naersk' = pkgs.callPackage naersk {
+          cargo = toolchain;
+          rustc = toolchain;
+        };
+        code = naersk'.buildPackage {
+          src = ./.;
+        };
+      in rec {
+        packages = {
+          cli = code;
+          default = packages.cli;
+        };
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            openssl
+            pkg-config
+            cmake
+            rust-bin.beta.latest.default
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Nix flakes allow caching and all sorts of other nice things in development shells, plus they would allow you to run `nix profile install github:railwayapp/cliv3` to install it on NixOS.