### PR TITLE
Allow a user to Generate a Service Domain from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Railway CLI (v3)
+# Railway CLI (3.x.x)
 
 [![CI](https://github.com/railwayapp/cliv3/actions/workflows/ci.yml/badge.svg)](https://github.com/railwayapp/cliv3/actions/workflows/ci.yml)
 
@@ -6,6 +6,14 @@ This is the command line interface for [Railway](https://railway.app). Use it to
 
 [View the docs](https://docs.railway.app/develop/cli)
 
+The Railway command line interface (CLI) connects your code to your Railway project from the command line.
+
+The Railway CLI allows you to
+
+- Create new Railway projects from the terminal
+- Link to an existing Railway project
+- Pull down environment variables for your project locally to run
+- Create services and databases right from the comfort of your fingertips
 ## Status
 Currently pre-release. We are looking for feedback and suggestions. Please join our [Discord](https://discord.gg/railway) to provide feedback.
 

--- a/src/commands/domain.rs
+++ b/src/commands/domain.rs
@@ -1,0 +1,101 @@
+use std::time::Duration;
+
+use anyhow::bail;
+
+use crate::consts::TICK_STRING;
+
+use super::*;
+
+// Generates a domain for a service if there is not a railway provided domain
+#[derive(Parser)]
+
+// Checks if the user is linked to a service, if not, it will generate a domain for the default service
+
+pub struct Args {}
+
+pub async fn command(_args: Args, _json: bool) -> Result<()> {
+    let configs = Configs::new()?;
+
+    let client = GQLClient::new_authorized(&configs)?;
+    let linked_project = configs.get_linked_project()?;
+
+    let vars = queries::project::Variables {
+        id: linked_project.project.to_owned(),
+    };
+
+    let res = post_graphql::<queries::Project, _>(
+        &client,
+        "https://backboard.railway.app/graphql/v2",
+        vars,
+    )
+    .await?;
+
+    let body = res.data.context("Failed to retrieve response body")?;
+
+    if body.project.services.edges.len() == 0 {
+        bail!("No services found for project");
+    }
+
+    // If there is only one service, it will generate a domain for that service
+    let service = if body.project.services.edges.len() == 1 {
+        body.project.services.edges[0].node.clone().id
+    } else {
+        let Some(service) = linked_project.service.clone() else {
+        bail!("No service linked");
+      };
+        service.clone()
+    };
+
+    let vars = queries::service_domains::Variables {
+        project_id: linked_project.project.clone(),
+        environment_id: linked_project.environment.clone(),
+        service_id: service.clone(),
+    };
+
+    let res = post_graphql::<queries::ServiceDomains, _>(
+        &client,
+        "https://backboard.railway.app/graphql/v2",
+        vars,
+    )
+    .await?;
+
+    let body = res
+        .data
+        .context("Failed to retrieve to get domains for service.")?;
+
+    let domain = body.domains;
+    if domain.service_domains.len() > 0 || domain.custom_domains.len() > 0 {
+        bail!("Domain already exists on service");
+    }
+
+    let spinner = indicatif::ProgressBar::new_spinner()
+        .with_style(
+            indicatif::ProgressStyle::default_spinner()
+                .tick_chars(TICK_STRING)
+                .template("{spinner:.green} {msg}")?,
+        )
+        .with_message(format!("Creating domain..."));
+    spinner.enable_steady_tick(Duration::from_millis(100));
+
+    let vars = mutations::service_domain_create::Variables {
+        service_id: service,
+        environment_id: linked_project.environment.clone(),
+    };
+
+    let res = post_graphql::<mutations::ServiceDomainCreate, _>(
+        &client,
+        "https://backboard.railway.app/graphql/v2",
+        vars,
+    )
+    .await?;
+
+    let body = res.data.context("Failed to create service domain.")?;
+
+    let domain = body.service_domain_create.domain;
+
+    spinner.finish_and_clear();
+
+    println!("Service Domain created: {}", domain.bold());
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod add;
 pub mod completion;
 pub mod delete;
 pub mod docs;
+pub mod domain;
 pub mod environment;
 pub mod init;
 pub mod link;

--- a/src/gql/mutations/mod.rs
+++ b/src/gql/mutations/mod.rs
@@ -31,3 +31,11 @@ pub struct ValidateTwoFactor;
     response_derives = "Debug, Serialize, Clone"
 )]
 pub struct ProjectCreate;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/mutations/strings/ServiceDomainCreate.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct ServiceDomainCreate;

--- a/src/gql/mutations/strings/ServiceDomainCreate.graphql
+++ b/src/gql/mutations/strings/ServiceDomainCreate.graphql
@@ -1,0 +1,8 @@
+mutation ServiceDomainCreate($environmentId: String!, $serviceId: String!) {
+  serviceDomainCreate(
+    input: { environmentId: $environmentId, serviceId: $serviceId }
+  ) {
+    id
+    domain
+  }
+}

--- a/src/gql/queries/mod.rs
+++ b/src/gql/queries/mod.rs
@@ -74,3 +74,11 @@ pub struct Deployments;
     response_derives = "Debug, Serialize, Clone"
 )]
 pub struct BuildLogs;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "src/gql/schema.graphql",
+    query_path = "src/gql/queries/strings/ServiceDomains.graphql",
+    response_derives = "Debug, Serialize, Clone"
+)]
+pub struct ServiceDomains;

--- a/src/gql/queries/strings/ServiceDomains.graphql
+++ b/src/gql/queries/strings/ServiceDomains.graphql
@@ -1,0 +1,18 @@
+query ServiceDomains(
+  $environmentId: String!
+  $projectId: String!
+  $serviceId: String!
+) {
+  domains(
+    environmentId: $environmentId
+    projectId: $projectId
+    serviceId: $serviceId
+  ) {
+    serviceDomains {
+      id
+    }
+    customDomains {
+      id
+    }
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ commands_enum!(
     add,
     completion,
     delete,
+    domain,
     docs,
     environment,
     init,


### PR DESCRIPTION
This feature allows a user to add a Railway generated domain on a service.

If there is already a Service Domain or Custom Domain on the service, then we will error and exit the flow.

When successful, we return the domain that was created back to the end user. 

This is useful for when users are interacting with the `railway up` flow and don't want to enter into the UI.