### PR TITLE
Respect `.railwayignore`

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -53,6 +53,7 @@ pub async fn command(args: Args, _json: bool) -> Result<()> {
     {
         let mut archive = Builder::new(&mut parz);
         let mut builder = WalkBuilder::new(args.path.unwrap_or_else(|| ".".into()));
+        builder.add_custom_ignore_filename(".railwayignore");
         let walker = builder.follow_links(true).hidden(false);
         let walked = walker.build().collect::<Vec<_>>();
         if let Some(spinner) = spinner {


### PR DESCRIPTION
Previously only `.gitignore` was handled, now we handle custom `.railwayignore`'s as well